### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Note that the user requires the PROCESS priviledge to collect the information.
 When `ActiveRecord::ConnectionTimeoutError` occurs, you can see the information of connection owners (threads):
 
 ```
-ActiveRecord::ConnectionTimeoutError occured:
+ActiveRecord::ConnectionTimeoutError occurred:
   connection owners:
     Thread #<Thread:0x00007fbda205fa70 sleep_forever> status=sleep priority=0
         /path/to/activerecord-debug_errors/spec/activerecord/debug_errors/ext/connection_adapters/connection_pool_spec.rb:32:in `join'

--- a/lib/activerecord/debug_errors/ext/connection_adapters/connection_pool.rb
+++ b/lib/activerecord/debug_errors/ext/connection_adapters/connection_pool.rb
@@ -15,7 +15,7 @@ module ActiveRecord
       def dump_threads
         logger = ActiveRecord::Base.logger
 
-        logger.error "ActiveRecord::ConnectionTimeoutError occured:"
+        logger.error "ActiveRecord::ConnectionTimeoutError occurred:"
 
         dump_thread = ->(thread) {
           logger.error "    Thread #{thread} status=#{thread.status} priority=#{thread.priority}"

--- a/spec/activerecord/debug_errors/ext/connection_adapters/connection_pool_spec.rb
+++ b/spec/activerecord/debug_errors/ext/connection_adapters/connection_pool_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ActiveRecord::DebugErrors::DisplayConnectionOwners do
         end.each(&:join)
       }.to raise_error(ActiveRecord::ConnectionTimeoutError)
 
-      expect(log.string).to include("ActiveRecord::ConnectionTimeoutError occured:")
+      expect(log.string).to include("ActiveRecord::ConnectionTimeoutError occurred:")
       expect(log.string).to include("connection owners:")
       expect(log.string).to include("other threads")
 


### PR DESCRIPTION
This just fixes a typo in the error message.

https://www.oxfordlearnersdictionaries.com/definition/english/occur