### PR TITLE
Use actions/checkout@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/activerecord_${{ matrix.activerecord-version }}.gemfile
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This updates the `actions/checkout` version since v2 is already outdated as GitHub Actions says.

<img width="1544" alt="image" src="https://github.com/abicky/activerecord-debug_errors/assets/1811616/9cf92681-9bb8-46a6-9330-f8840b3b0bd9">


ref https://github.com/actions/checkout

