### PR TITLE
Fix broken badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ActiveRecord::DebugErrors
 
-![](https://github.com/abicky/activerecord-debug_errors/workflows/CI/badge.svg?branch=master)
+[![CI](https://github.com/abicky/activerecord-debug_errors/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/abicky/activerecord-debug_errors/actions/workflows/test.yml)
 
 ActiveRecord::DebugErrors is an extension of activerecord to display useful debug logs on errors.
 


### PR DESCRIPTION
This fixes the broken badge on README so that a potential user can feel relieved. 😉 

## Rich diff

<img width="784" alt="image" src="https://github.com/abicky/activerecord-debug_errors/assets/1811616/17d9273d-7762-4e80-ae19-2febf827d31e">
