### PR TITLE
Run CI tests against Rails 7.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,15 @@ jobs:
           - '6_1'
           - '7_0'
           - '7_1'
+          - '7_2'
           - 'latest'
         mysql-version:
           - '5.7'
           - '8.0'
+        exclude:
+          # activerecord-7 doesn't support Ruby 2.6
+          - ruby-version: '3.0'
+            activerecord-version: '7_2'
 
     services:
       mysql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           - '5.7'
           - '8.0'
         exclude:
-          # activerecord-7 doesn't support Ruby 2.6
+          # activerecord-7.2 requires Ruby 3.1.0 or later
           - ruby-version: '3.0'
             activerecord-version: '7_2'
 

--- a/gemfiles/activerecord_7_2.gemfile
+++ b/gemfiles/activerecord_7_2.gemfile
@@ -1,0 +1,2 @@
+eval_gemfile("../Gemfile")
+gem "activerecord", "~> 7.2.0"


### PR DESCRIPTION
Hi, based on [Rails 7.2 release](https://rubyonrails.org/2024/8/10/Rails-7-2-0-has-been-released), this pull request makes CI run tests against Rails 7.2.