### PR TITLE
Fix flaky test

### DIFF
--- a/spec/support/cyclic_barrier.rb
+++ b/spec/support/cyclic_barrier.rb
@@ -1,0 +1,21 @@
+# This class is a simple implementation of CyclicBarrier in Java
+class CyclicBarrier
+  def initialize(parties)
+    @cv = ConditionVariable.new
+    @mutex = Mutex.new
+    @parties = parties
+    @number_waiting = 0
+  end
+
+  def await(timeout = nil)
+    @mutex.synchronize do
+      @number_waiting += 1
+      if @number_waiting == @parties
+        @cv.broadcast
+      else
+        @cv.wait(@mutex, timeout)
+        raise Timeout::Error if @number_waiting != @parties
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the flaky test "ActiveRecord::DebugErrors::DisplayConnectionOwners#execute when ActiveRecord::LockWaitTimeout occurs displays transactions and processlist."
I suspect there is more than 1 second time delay between the start time of the two threads, and CyclicBarrier is expected to shorten the delay.