### PR TITLE
Increase sleep time to fix flaky test

### DIFF
--- a/spec/activerecord/debug_errors/ext/connection_adapters/abstract_mysql_adapter_spec.rb
+++ b/spec/activerecord/debug_errors/ext/connection_adapters/abstract_mysql_adapter_spec.rb
@@ -74,10 +74,11 @@ RSpec.describe ActiveRecord::DebugErrors::DisplayConnectionOwners do
 
         ths = Array.new(2) do
           Thread.new do
+            Thread.current.abort_on_exception = true
             User.transaction do
               barrier.await(1)
               User.lock.find_by!(name: 'foo')
-              sleep 2
+              sleep 5
             end
           end
         end


### PR DESCRIPTION
InnoDB seems to raise the error "Lock wait timeout exceeded" more than innodb_lock_wait_timeout seconds.
I've checked the behavior with the following changes:

```diff
diff --git a/spec/activerecord/debug_errors/ext/connection_adapters/abstract_mysql_adapter_spec.rb b/spec/activerecord/debug_errors/ext/connection_adapters/abstract_mysql_adapter_spec.rb
index d76df70..e206b8e 100644
--- a/spec/activerecord/debug_errors/ext/connection_adapters/abstract_mysql_adapter_spec.rb
+++ b/spec/activerecord/debug_errors/ext/connection_adapters/abstract_mysql_adapter_spec.rb
@@ -71,17 +71,23 @@ RSpec.describe ActiveRecord::DebugErrors::DisplayConnectionOwners do
     context "when ActiveRecord::LockWaitTimeout occurs" do
       it "displays transactions and processlist" do
         barrier = CyclicBarrier.new(2)
-
+        logger = Logger.new($stderr)
         ths = Array.new(2) do
           Thread.new do
             User.transaction do
               barrier.await(1)
+              logger.info("#{Thread.current.object_id}: #{User.connection.execute("show variables like 'innodb_lock_wait_timeout'").to_a.first.join('=')}")
+              logger.info("#{Thread.current.object_id}: User.lock.find_by!")
               User.lock.find_by!(name: 'foo')
               sleep 2
+              logger.info("#{Thread.current.object_id}: done")
             end
           end
         end

+        ths.each.with_index do |th, i|
+          logger.info("ths[#{i}].object_id = #{th.object_id}")
+        end
         expect {
           ths.each(&:join)
         }.to raise_error(ActiveRecord::LockWaitTimeout)
```

Here is an output when the test failed:

```
I, [2024-10-05T11:34:24.178954 #2382]  INFO -- : ths[0].object_id = 4640
I, [2024-10-05T11:34:24.179319 #2382]  INFO -- : ths[1].object_id = 4660
I, [2024-10-05T11:34:24.182214 #2382]  INFO -- : 4640: innodb_lock_wait_timeout=1
I, [2024-10-05T11:34:24.182242 #2382]  INFO -- : 4640: User.lock.find_by!
I, [2024-10-05T11:34:24.195809 #2382]  INFO -- : 4660: innodb_lock_wait_timeout=1
I, [2024-10-05T11:34:24.195828 #2382]  INFO -- : 4660: User.lock.find_by!
I, [2024-10-05T11:34:26.183071 #2382]  INFO -- : 4640: done
I, [2024-10-05T11:34:28.184163 #2382]  INFO -- : 4660: done
```
