### PR TITLE
Support activerecord 8.0 explicitly and drop support of Ruby 3.0 and MySQL 5.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'
@@ -28,20 +27,13 @@ jobs:
           - '8_0'
           - 'latest'
         mysql-version:
-          - '5.7'
           - '8.0'
         exclude:
           # Exclude conditions that don't meat the minimal requirement
-          - ruby-version: '3.0'
-            activerecord-version: '7_2'
-          - ruby-version: '3.0'
-            activerecord-version: '8_0'
           - ruby-version: '3.1'
             activerecord-version: '8_0'
 
           # Exclude duplicate conditions
-          - ruby-version: '3.0'
-            activerecord-version: 'latest' # equivalent to '7_1'
           - ruby-version: '3.1'
             activerecord-version: 'latest' # equivalent to '7_2'
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,15 +25,25 @@ jobs:
           - '7_0'
           - '7_1'
           - '7_2'
+          - '8_0'
           - 'latest'
         mysql-version:
           - '5.7'
           - '8.0'
         exclude:
-          # activerecord-7.2 requires Ruby 3.1.0 or later
+          # Exclude conditions that don't meat the minimal requirement
           - ruby-version: '3.0'
             activerecord-version: '7_2'
+          - ruby-version: '3.0'
+            activerecord-version: '8_0'
+          - ruby-version: '3.1'
+            activerecord-version: '8_0'
 
+          # Exclude duplicate conditions
+          - ruby-version: '3.0'
+            activerecord-version: 'latest' # equivalent to '7_1'
+          - ruby-version: '3.1'
+            activerecord-version: 'latest' # equivalent to '7_2'
     services:
       mysql:
         image: mysql:${{ matrix.mysql-version }}
@@ -58,6 +68,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+      - name: Show activerecord version
+        run: bundle info activerecord
       - name: Run tests
         run: |
           bundle exec rake

--- a/gemfiles/activerecord_8_0.gemfile
+++ b/gemfiles/activerecord_8_0.gemfile
@@ -1,0 +1,2 @@
+eval_gemfile("../Gemfile")
+gem "activerecord", "~> 8.0.0"


### PR DESCRIPTION
* activerecord 8.0 was released on November 7, 2024
    - cf. https://rubygems.org/gems/activerecord/versions/8.0.0
* Ruby 3.0 has already reached its EOL
    - cf. https://www.ruby-lang.org/en/downloads/branches/
* MySQL 5.7 has already reached its EOL
    <img width="675" alt="image" src="https://github.com/user-attachments/assets/5461aa12-6b94-4f39-a29f-7655f1d7b22d">
    cf. https://www.oracle.com/us/assets/lifetime-support-technology-069183.pdf