### PR TITLE
Support activerecord 8.1 explicitly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           - '7_1'
           - '7_2'
           - '8_0'
+          - '8_1'
           - 'latest'
         mysql-version:
           - '8.0'
@@ -33,6 +34,8 @@ jobs:
           # Exclude conditions that don't meat the minimal requirement
           - ruby-version: '3.1'
             activerecord-version: '8_0'
+          - ruby-version: '3.1'
+            activerecord-version: '8_1'
 
           # Exclude duplicate conditions
           - ruby-version: '3.1'

--- a/gemfiles/activerecord_8_1.gemfile
+++ b/gemfiles/activerecord_8_1.gemfile
@@ -1,0 +1,2 @@
+eval_gemfile("../Gemfile")
+gem "activerecord", "~> 8.1.0"


### PR DESCRIPTION
## Change

This adds activerecord 8.1 into the test matrix since activerecord 8.1 was released on October 22, 2025.

ref: https://rubygems.org/gems/activerecord/versions/8.1.0

8.1 still requires Ruby 3.2 or later as like 8.0 does.

## Testing

Some tests fail on 8.1. I'll check it later.
https://github.com/ohbarye/activerecord-debug_errors/actions/runs/19865227719/job/56925996094